### PR TITLE
Backtrace: don't add first line if useless

### DIFF
--- a/lib/Errbit/Notice.php
+++ b/lib/Errbit/Notice.php
@@ -167,11 +167,15 @@ class Errbit_Notice {
 						$trace = $exception->getTrace();
 
 						$file1 = $exception->getFile();
-						$backtrace->tag('line', array(
-							'number' => $exception->getLine(),
-							'file' => !empty($file1) ? $self->filterTrace($file1) : '<unknown>',
-							'method' =>  "<unknown>"
-						));
+						// if there isn't even a file path, dont bother adding a 
+						// rather useless "<unknown> -> <unknown>" stack line.
+						if ($file1) {
+							$backtrace->tag('line', array(
+								'number' => $exception->getLine(),
+								'file' => !empty($file1) ? $self->filterTrace($file1) : '<unknown>',
+								'method' =>  "<unknown>"
+							));
+						}
 
 						// if there is no trace we should add an empty element
 						if (empty($trace)) {


### PR DESCRIPTION
I'm running into a scenario where I'm modifying the stack trace of the
exception being reported. I have the method for the first line, but
php Exceptions don't have a getFunction() to match their getFile() and
getLine(). This change allows including the *whole* stack trace in
getTrace() and having it report correctly.